### PR TITLE
Annotation improvements

### DIFF
--- a/jot.podspec
+++ b/jot.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name		= "jot"
-  s.version		= "0.1.5"
+  s.version		= "0.1.6"
   s.summary		= "An easy way to add drawings and text to images"
   s.homepage		= "https://github.com/IFTTT/jot"
   s.license		= 'MIT'

--- a/jot.podspec
+++ b/jot.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.compiler_flags	= '-fmodules'
   s.frameworks		= 'UIKit'
 
-  s.dependency		  'Masonry', '~> 0.6.1'
+  s.dependency		  'Masonry', '~> 1.1.0'
   s.source_files	= 'jot/*.{h,m}'
   s.resources = 'jot/jot.bundle'
 

--- a/jot/JotTextEditView.m
+++ b/jot/JotTextEditView.m
@@ -76,7 +76,7 @@
         [colorSelector setShadowImage:[UIImage new]
                 forToolbarPosition:UIBarPositionAny];
       
-        NSArray *colors = @[[UIColor whiteColor],[UIColor jotBlack],[UIColor jotBlue],[UIColor jotGreen],[UIColor jotYellow],[UIColor jotCoral],[UIColor jotPurple]];
+        NSArray *colors = @[[UIColor whiteColor],[UIColor jotNavy],[UIColor jotBlue],[UIColor jotGreen], [UIColor jotTurquoise], [UIColor jotSalmon], [UIColor jotCoral]];
         NSMutableArray *colorSelectorItems = [[NSMutableArray alloc] init];
         for (UIColor *color in colors) {
             CircleLineButton *colorButton = [[CircleLineButton alloc] initWithFrame:CGRectMake(0,0,35,35)];
@@ -336,7 +336,7 @@
     switch (self.backgroundColorMode.colorMode) {
         case JOTTextColorModeOpaqueBackground:
             if ([button.color isEqual:[UIColor whiteColor]]) {
-                self.textColor = [UIColor jotBlack];
+                self.textColor = [UIColor jotNavy];
             } else {
                 self.textColor = [UIColor whiteColor];
             }
@@ -347,7 +347,7 @@
         
         case JOTTextColorModeTransparentBackground:
             if ([button.color isEqual:[UIColor whiteColor]]) {
-                self.textColor = [UIColor jotBlack];
+                self.textColor = [UIColor jotNavy];
             } else {
                 self.textColor = [UIColor whiteColor];
             }
@@ -372,7 +372,7 @@
     
     switch (self.backgroundColorMode.colorMode) {
         case JOTTextColorModeOpaqueBackground:
-            self.textColor = [UIColor jotBlack];
+            self.textColor = [UIColor jotNavy];
             self.backgroundColor = [UIColor.whiteColor colorWithAlphaComponent:1.0];
             break;
             

--- a/jot/JotTextEditView.m
+++ b/jot/JotTextEditView.m
@@ -14,6 +14,8 @@
 
 #import "UIColor+Jot.h"
 
+static const NSUInteger kCharachterLimit = 140;
+
 @interface JotTextEditView () <UITextViewDelegate>
 
 @property (nonatomic, strong) UITextView *textView;
@@ -316,7 +318,7 @@
         return NO;
     }
     
-    if (textView.text.length + (text.length - range.length) > 70) {
+    if (textView.text.length + (text.length - range.length) > kCharachterLimit) {
         return NO;
     }
     

--- a/jot/JotTextEditView.m
+++ b/jot/JotTextEditView.m
@@ -85,10 +85,14 @@
             UIView *buttonView = [[UIView alloc] initWithFrame:CGRectMake(0,0,40,40)];
             [buttonView addSubview:colorButton];
             [colorSelectorItems addObject:[[UIBarButtonItem alloc] initWithCustomView:buttonView]];
+
+            // Add a UIBarButtonItem with FlexibleSpace to evenly distribute BarButtons across UIToolbar
+            [colorSelectorItems addObject:[[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil]];
         }
+
         [colorSelector setItems:colorSelectorItems animated:NO];
         self.textView.inputAccessoryView = colorSelector;
-        
+
         self.backgroundColorMode = [[TextColorModeButton alloc] init];
         self.backgroundColorMode.hidden = YES;
         self.backgroundColorMode.enabled = NO;

--- a/jot/JotTextEditView.m
+++ b/jot/JotTextEditView.m
@@ -14,7 +14,7 @@
 
 #import "UIColor+Jot.h"
 
-static const NSUInteger kCharachterLimit = 140;
+static const NSUInteger kCharacterLimit = 140;
 
 @interface JotTextEditView () <UITextViewDelegate>
 
@@ -78,7 +78,7 @@ static const NSUInteger kCharachterLimit = 140;
         [colorSelector setShadowImage:[UIImage new]
                 forToolbarPosition:UIBarPositionAny];
       
-        NSArray *colors = @[[UIColor whiteColor],[UIColor jotNavy],[UIColor jotBlue],[UIColor jotGreen], [UIColor jotTurquoise], [UIColor jotSalmon], [UIColor jotCoral]];
+        NSArray *colors = @[[UIColor whiteColor], [UIColor patreonNavy], [UIColor patreonBlue], [UIColor patreonGreen], [UIColor patreonTurquoise], [UIColor patreonSalmon], [UIColor patreonCoral]];
         NSMutableArray *colorSelectorItems = [[NSMutableArray alloc] init];
         for (UIColor *color in colors) {
             CircleLineButton *colorButton = [[CircleLineButton alloc] initWithFrame:CGRectMake(0,0,35,35)];
@@ -318,7 +318,7 @@ static const NSUInteger kCharachterLimit = 140;
         return NO;
     }
     
-    if (textView.text.length + (text.length - range.length) > kCharachterLimit) {
+    if (textView.text.length + (text.length - range.length) > kCharacterLimit) {
         return NO;
     }
     
@@ -338,7 +338,7 @@ static const NSUInteger kCharachterLimit = 140;
     switch (self.backgroundColorMode.colorMode) {
         case JOTTextColorModeOpaqueBackground:
             if ([button.color isEqual:[UIColor whiteColor]]) {
-                self.textColor = [UIColor jotNavy];
+                self.textColor = [UIColor patreonNavy];
             } else {
                 self.textColor = [UIColor whiteColor];
             }
@@ -349,7 +349,7 @@ static const NSUInteger kCharachterLimit = 140;
         
         case JOTTextColorModeTransparentBackground:
             if ([button.color isEqual:[UIColor whiteColor]]) {
-                self.textColor = [UIColor jotNavy];
+                self.textColor = [UIColor patreonNavy];
             } else {
                 self.textColor = [UIColor whiteColor];
             }
@@ -374,7 +374,7 @@ static const NSUInteger kCharachterLimit = 140;
     
     switch (self.backgroundColorMode.colorMode) {
         case JOTTextColorModeOpaqueBackground:
-            self.textColor = [UIColor jotNavy];
+            self.textColor = [UIColor patreonNavy];
             self.backgroundColor = [UIColor.whiteColor colorWithAlphaComponent:1.0];
             break;
             

--- a/jot/JotTextEditView.m
+++ b/jot/JotTextEditView.m
@@ -95,7 +95,12 @@
         [self addSubview:self.backgroundColorMode];
         [self.backgroundColorMode addTarget:self action:@selector(changeBackgroundColor:) forControlEvents:UIControlEventTouchDown];
         [self.backgroundColorMode mas_makeConstraints:^(MASConstraintMaker *make) {
-            make.top.equalTo(self).offset(20.f);
+            // Respect safeArea on iOS11
+            if (@available(iOS 11.0, *)) {
+              make.top.equalTo(self.mas_safeAreaLayoutGuideTop).offset(20.f);
+            } else {
+              make.top.equalTo(self).offset(20.f);
+            }
             make.centerX.equalTo(self.mas_centerX);
             make.width.equalTo(@30);
             make.height.equalTo(@30);

--- a/jot/JotTextEditView.m
+++ b/jot/JotTextEditView.m
@@ -134,9 +134,9 @@
                                                           
                                                           CGFloat centerAboveKeyboard = keyboardRectEnd.origin.y / 2;
                                                           
-                                                          [self.textView mas_makeConstraints:^(MASConstraintMaker *make) {
+                                                          [self.textView mas_updateConstraints:^(MASConstraintMaker *make) {
                                                               make.top.equalTo(@(centerAboveKeyboard));
-                                                            }];
+                                                          }];
 
                                                           [UIView animateWithDuration:duration
                                                                                 delay:0.f

--- a/jot/JotTextView.m
+++ b/jot/JotTextView.m
@@ -9,7 +9,7 @@
 #import "JotTextView.h"
 
 static const CGFloat kTextMargin = 10.f;
-static const CGFloat kCornerRadius = 8.f;
+static const CGFloat kCornerRadius = 5.f;
 
 @interface JotTextView ()
 

--- a/jot/JotTextView.m
+++ b/jot/JotTextView.m
@@ -36,7 +36,7 @@ static const CGFloat kCornerRadius = 5.f;
         
         _initialTextInsets = UIEdgeInsetsMake(0.f, 0.f, 0.f, 0.f);
         
-        _fontSize = 60.f;
+        _fontSize = 24.f;
         _scale = 1.f;
         _font = [UIFont systemFontOfSize:self.fontSize];
         _textAlignment = NSTextAlignmentCenter;

--- a/jot/JotTextView.m
+++ b/jot/JotTextView.m
@@ -8,6 +8,9 @@
 
 #import "JotTextView.h"
 
+static const CGFloat kTextMargin = 10.f;
+static const CGFloat kCornerRadius = 8.f;
+
 @interface JotTextView ()
 
 @property (nonatomic, strong) UILabel *textLabel;
@@ -47,7 +50,7 @@
         self.textLabel.textColor = self.textColor;
         self.textLabel.textAlignment = self.textAlignment;
         self.textLabel.clipsToBounds = YES;
-        self.textLabel.layer.cornerRadius = 5;
+        self.textLabel.layer.cornerRadius = kCornerRadius;
         self.textLabel.center = CGPointMake(CGRectGetMidX([UIScreen mainScreen].bounds),
                                             CGRectGetMidY([UIScreen mainScreen].bounds));
         self.referenceCenter = CGPointZero;
@@ -105,11 +108,12 @@
         CGPoint labelCenter = self.textLabel.center;
         CGRect scaledLabelFrame = CGRectMake(0.f,
                                              0.f,
-                                             CGRectGetWidth(_labelFrame) * _scale * 1.05f,
-                                             CGRectGetHeight(_labelFrame) * _scale * 1.05f);
+                                             (CGRectGetWidth(_labelFrame) * _scale) + kTextMargin,
+                                             (CGRectGetHeight(_labelFrame) * _scale) + kTextMargin);
         CGFloat currentFontSize = self.fontSize * _scale;
         self.textLabel.font = [self.font fontWithSize:currentFontSize];
         self.textLabel.frame = scaledLabelFrame;
+        self.textLabel.layer.cornerRadius = _scale * kCornerRadius;
         self.textLabel.center = labelCenter;
         self.textLabel.transform = self.currentRotateTransform;
     }
@@ -180,10 +184,11 @@
         CGPoint labelCenter = self.textLabel.center;
         CGRect scaledLabelFrame = CGRectMake(0.f,
                                              0.f,
-                                             CGRectGetWidth(_labelFrame) * _scale * 1.05f,
-                                             CGRectGetHeight(_labelFrame) * _scale * 1.05f);
+                                             (CGRectGetWidth(_labelFrame) * _scale) + kTextMargin,
+                                             (CGRectGetHeight(_labelFrame) * _scale) + kTextMargin);
         CGAffineTransform labelTransform = self.textLabel.transform;
         self.textLabel.transform = CGAffineTransformIdentity;
+        self.textLabel.layer.cornerRadius = _scale * kCornerRadius;
         self.textLabel.frame = scaledLabelFrame;
         self.textLabel.transform = labelTransform;
         self.textLabel.center = labelCenter;
@@ -223,8 +228,8 @@
     CGSize originalSize = [temporarySizingLabel sizeThatFits:insetViewRect.size];
     temporarySizingLabel.frame = CGRectMake(0.f,
                                             0.f,
-                                            originalSize.width * 1.05f,
-                                            originalSize.height * 1.05f);
+                                            originalSize.width + kTextMargin,
+                                            originalSize.height + kTextMargin);
     temporarySizingLabel.center = self.textLabel.center;
     self.labelFrame = temporarySizingLabel.frame;
 }

--- a/jot/UIColor+Jot.h
+++ b/jot/UIColor+Jot.h
@@ -10,11 +10,11 @@
 
 @interface UIColor (Jot)
 
-+ (UIColor *)jotNavy;
-+ (UIColor *)jotBlue;
-+ (UIColor *)jotGreen;
-+ (UIColor *)jotTurquoise;
-+ (UIColor *)jotCoral;
-+ (UIColor *)jotSalmon;
++ (UIColor *)patreonNavy;
++ (UIColor *)patreonBlue;
++ (UIColor *)patreonGreen;
++ (UIColor *)patreonTurquoise;
++ (UIColor *)patreonCoral;
++ (UIColor *)patreonSalmon;
 
 @end

--- a/jot/UIColor+Jot.h
+++ b/jot/UIColor+Jot.h
@@ -10,11 +10,11 @@
 
 @interface UIColor (Jot)
 
-+ (UIColor *)jotBlack;
++ (UIColor *)jotNavy;
 + (UIColor *)jotBlue;
 + (UIColor *)jotGreen;
-+ (UIColor *)jotYellow;
++ (UIColor *)jotTurquoise;
 + (UIColor *)jotCoral;
-+ (UIColor *)jotPurple;
++ (UIColor *)jotSalmon;
 
 @end

--- a/jot/UIColor+Jot.m
+++ b/jot/UIColor+Jot.m
@@ -13,28 +13,28 @@
 
 @implementation UIColor (Jot)
 
-+ (UIColor *)jotBlack {
-    return UIColorFromRGB(0x4A4A4A);
++ (UIColor *)jotNavy {
+    return UIColorFromRGB(0x052D49);
 }
 
 + (UIColor *)jotBlue {
-    return UIColorFromRGB(0x4A90E2);
+    return UIColorFromRGB(0x358EFF);
 }
 
 + (UIColor *)jotGreen {
-    return UIColorFromRGB(0x7ED321);
+    return UIColorFromRGB(0x63D6A3);
 }
 
-+ (UIColor *)jotYellow {
-    return UIColorFromRGB(0xF8E81C);
++ (UIColor *)jotTurquoise {
+    return UIColorFromRGB(0x006375);
 }
 
 + (UIColor *)jotCoral {
-    return UIColorFromRGB(0xF5A623);
+    return UIColorFromRGB(0xF96854);
 }
 
-+ (UIColor *)jotPurple {
-    return UIColorFromRGB(0xBD10E0);
++ (UIColor *)jotSalmon {
+    return UIColorFromRGB(0xFF9B7A);
 }
 
 @end

--- a/jot/UIColor+Jot.m
+++ b/jot/UIColor+Jot.m
@@ -13,27 +13,27 @@
 
 @implementation UIColor (Jot)
 
-+ (UIColor *)jotNavy {
++ (UIColor *)patreonNavy {
     return UIColorFromRGB(0x052D49);
 }
 
-+ (UIColor *)jotBlue {
++ (UIColor *)patreonBlue {
     return UIColorFromRGB(0x358EFF);
 }
 
-+ (UIColor *)jotGreen {
++ (UIColor *)patreonGreen {
     return UIColorFromRGB(0x63D6A3);
 }
 
-+ (UIColor *)jotTurquoise {
++ (UIColor *)patreonTurquoise {
     return UIColorFromRGB(0x006375);
 }
 
-+ (UIColor *)jotCoral {
++ (UIColor *)patreonCoral {
     return UIColorFromRGB(0xF96854);
 }
 
-+ (UIColor *)jotSalmon {
++ (UIColor *)patreonSalmon {
     return UIColorFromRGB(0xFF9B7A);
 }
 


### PR DESCRIPTION
Fixes a number of bugs related to layout of text annotations.

- Update Masonry dependency to 1.1.0 for iOS 11 safeArea support
- Respect safeArea when displaying the backgroundColorMode button
- Fix broken constraint when updating textView position
- Better layout of color selector UIBarButtonItems thanks to UIBarButtonSystemItemFlexibleSpace
- Update available color picker colors
- Make character limit a constant and change it from 70 to 140
- Fix how TextViews are calculated and scaled
- Change cornerRadius from 5 to 8
- Make cornerRadius and textMargin both constants